### PR TITLE
Pythonanywhere

### DIFF
--- a/radar_project/radar_project/settings.py
+++ b/radar_project/radar_project/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = '6$tbs2_&$^%zht1tmb9!q^uk0&zs(@k2^-zf0lx2)numua__3v'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['radar.pythonanywhere.com'] # added
+ALLOWED_HOSTS = ['radar.pythonanywhere.com', '127.0.0.1'] # added
 
 
 # Application definition

--- a/radar_project/radar_project/settings.py
+++ b/radar_project/radar_project/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = '6$tbs2_&$^%zht1tmb9!q^uk0&zs(@k2^-zf0lx2)numua__3v'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['radar.pythonanywhere.com']
 
 
 # Application definition

--- a/radar_project/radar_project/settings.py
+++ b/radar_project/radar_project/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = '6$tbs2_&$^%zht1tmb9!q^uk0&zs(@k2^-zf0lx2)numua__3v'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['radar.pythonanywhere.com']
+ALLOWED_HOSTS = ['radar.pythonanywhere.com'] # added
 
 
 # Application definition


### PR DESCRIPTION
added radar pythonanywhere website url to allowed hosts list in settings py
127.0.0.1 is added to allowed host list in settings py for now so that local computer can also access it when runserver - but this needs to remove before final production"